### PR TITLE
feat: Windows: added line_height to canvas.py

### DIFF
--- a/winforms/src/toga_winforms/widgets/canvas.py
+++ b/winforms/src/toga_winforms/widgets/canvas.py
@@ -300,15 +300,14 @@ class Canvas(Box):
         self.scale(self.dpi_scale, self.dpi_scale, draw_context)
 
     # Text
-    def write_text(self, text, x, y, font, baseline, draw_context, **kwargs):
+    def write_text(self, text, x, y, font, baseline, draw_context, line_height, **kwargs):
         for op in ["fill", "stroke"]:
             if color := kwargs.pop(f"{op}_color", None):
-                self._text_path(text, x, y, font, baseline, draw_context)
+                self._text_path(text, x, y, font, baseline, draw_context, line_height)
                 getattr(self, op)(color, draw_context=draw_context, **kwargs)
 
-    def _text_path(self, text, x, y, font, baseline, draw_context):
+    def _text_path(self, text, x, y, font, baseline, draw_context, line_height):
         lines = text.splitlines()
-        line_height = font.metric("LineSpacing")
         total_height = line_height * len(lines)
 
         if baseline == Baseline.TOP:
@@ -331,7 +330,7 @@ class Canvas(Box):
                 self.string_format,
             )
 
-    def measure_text(self, text, font):
+    def measure_text(self, text, font, line_height):
         graphics = self.native.CreateGraphics()
         sizes = [
             graphics.MeasureString(line, font.native, 2**31 - 1, self.string_format)
@@ -339,7 +338,7 @@ class Canvas(Box):
         ]
         return (
             self.scale_out(max(size.Width for size in sizes)),
-            font.metric("LineSpacing") * len(sizes),
+            line_height * len(sizes),
         )
 
     def get_image_data(self):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added a line_height parameter to write_text, _text_path and measure_text, in order for the user to be able to customize the line height of their text. This addition was done to the canvas.py file for winforms.
<!--- What problem does this change solve? -->
It makes it so that the core method can use these methods in order to customize the line height, which will enable this feature to be developed.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #3 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
