### PR TITLE
bugfix: fix windows backend bug

### DIFF
--- a/changes/28.bugfix.rst
+++ b/changes/28.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed line_height_factor only allowing integers.

--- a/winforms/src/toga_winforms/widgets/canvas.py
+++ b/winforms/src/toga_winforms/widgets/canvas.py
@@ -301,16 +301,16 @@ class Canvas(Box):
 
     # Text
     def write_text(
-        self, text, x, y, font, baseline, draw_context, line_height_factor, **kwargs
+        self, text, x, y, font, baseline, line_height_factor, draw_context, **kwargs
     ):
         for op in ["fill", "stroke"]:
             if color := kwargs.pop(f"{op}_color", None):
                 self._text_path(
-                    text, x, y, font, baseline, draw_context, line_height_factor
+                    text, x, y, font, baseline, line_height_factor, draw_context
                 )
                 getattr(self, op)(color, draw_context=draw_context, **kwargs)
 
-    def _text_path(self, text, x, y, font, baseline, draw_context, line_height_factor):
+    def _text_path(self, text, x, y, font, baseline, line_height_factor, draw_context):
         lines = text.splitlines()
         line_height = font.metric("LineSpacing") * line_height_factor
         total_height = line_height * len(lines)

--- a/winforms/src/toga_winforms/widgets/canvas.py
+++ b/winforms/src/toga_winforms/widgets/canvas.py
@@ -301,7 +301,7 @@ class Canvas(Box):
 
     # Text
     def write_text(
-        self, text, x, y, font, baseline, draw_context, line_height_factor=1, **kwargs
+        self, text, x, y, font, baseline, draw_context, line_height_factor, **kwargs
     ):
         for op in ["fill", "stroke"]:
             if color := kwargs.pop(f"{op}_color", None):
@@ -335,7 +335,7 @@ class Canvas(Box):
                 self.string_format,
             )
 
-    def measure_text(self, text, font, line_height_factor=1):
+    def measure_text(self, text, font, line_height_factor):
         graphics = self.native.CreateGraphics()
         sizes = [
             graphics.MeasureString(line, font.native, 2**31 - 1, self.string_format)


### PR DESCRIPTION
Remove default value for line_height_factor. This already exists in the api (which calls write_text and measure_text) and thus is redundant. The default value being 1 also caused the issue of line_height_factor being an int and thus not accepting float values.