### PR TITLE
bugfix: remove default value and correct parameter order

### DIFF
--- a/android/src/toga_android/widgets/canvas.py
+++ b/android/src/toga_android/widgets/canvas.py
@@ -189,12 +189,7 @@ class Canvas(Widget):
 
     # Text
 
-    def measure_text(
-        self,
-        text,
-        font,
-        line_height_factor=1,
-    ):
+    def measure_text(self, text, font, line_height_factor):
         paint = self._text_paint(font)
         sizes = [paint.measureText(line) for line in text.splitlines()]
         return (
@@ -203,7 +198,7 @@ class Canvas(Widget):
         )
 
     def write_text(
-        self, text, x, y, font, baseline, canvas, line_height_factor=1, **kwargs
+        self, text, x, y, font, baseline, line_height_factor, canvas, **kwargs
     ):
         lines = text.splitlines()
         paint = self._text_paint(font)

--- a/changes/34.bugfix.rst
+++ b/changes/34.bugfix.rst
@@ -1,0 +1,1 @@
+Fix inability to set non-integer line_height_factor.

--- a/cocoa/src/toga_cocoa/widgets/canvas.py
+++ b/cocoa/src/toga_cocoa/widgets/canvas.py
@@ -273,7 +273,7 @@ class Canvas(Widget):
         # descender is a negative number.
         return ceil((font.native.ascender - font.native.descender) * line_height_factor)
 
-    def measure_text(self, text, font, line_height_factor=1):
+    def measure_text(self, text, font, line_height_factor):
         # We need at least a fill color to render, but that won't change the size.
         sizes = [
             self._render_string(line, font, fill_color=color(BLACK)).size()
@@ -284,7 +284,7 @@ class Canvas(Widget):
             self._line_height(font, line_height_factor) * len(sizes),
         )
 
-    def write_text(self, text, x, y, font, baseline, line_height_factor=1, **kwargs):
+    def write_text(self, text, x, y, font, baseline, line_height_factor, **kwargs):
         lines = text.splitlines()
         line_height = self._line_height(font, line_height_factor)
         total_height = line_height * len(lines)


### PR DESCRIPTION
Correct bugs in the android and macOS backends by removing line_height_factor default values and correcting the parameter order to match that in the api.